### PR TITLE
fix 'some english char can't search'

### DIFF
--- a/src/components/Fav.js
+++ b/src/components/Fav.js
@@ -176,9 +176,11 @@ export const Fav = (function ({ FavList, onSongIndexChange, onAddOneFromFav, han
             return
         }
 
+        const lowerCaseSearchedVal = searchedVal.toLowerCase();
         const filteredRows = FavList.songList.filter((row) => {
             // const cleanString = row.name.replace('《') // TODO: some english char can't search
-            return row.name.includes(searchedVal)
+            // return row.name.includes(searchedVal)
+            return row.name.toLowerCase().includes(lowerCaseSearchedVal)
         })
         setRows(filteredRows)
     }


### PR DESCRIPTION
在v1.3.0.0中，“搜索歌曲”栏是严格区分大小写的。尽管azusa-player显示的歌曲名中的英文字符皆为大写，但这与搜索栏调用`requestSearch`时的情况不同，推测`FavList.songList`是视频标题的原有样式，即大写字符为大写，小写字符为小写。又因`includes()`方法严格区分大小写，便导致了搜索栏输入英文字符时搜索结果没有显示的问题。