### PR TITLE
fix the padding of CRUDBtn

### DIFF
--- a/src/components/FavList.js
+++ b/src/components/FavList.js
@@ -35,9 +35,9 @@ const CRUDBtn = {
         cursor: 'default'
     },
     marginTop: '-30px',
-    paddingBottom: '30px',
+    paddingBottom: '8px',
     marginBottom: '-30px',
-    paddingTop: '30px',
+    paddingTop: '8px',
     paddingLeft: '8px',
     paddingRight: '8px'
 }


### PR DESCRIPTION
发现歌单名字太长的时候，右侧小按钮点击不了，f12凑了一眼发现是padding太大了

![image](https://github.com/user-attachments/assets/5283451a-1851-4e02-840d-6a85371d8674)

所以把上下的padding都改成8px
