### PR TITLE
修复“搜索歌单”功能在获取收藏夹视频列表时缺失最后一页的问题

### DIFF
--- a/src/components/Fav.js
+++ b/src/components/Fav.js
@@ -146,7 +146,7 @@ TablePaginationActions.propTypes = {
     rowsPerPage: PropTypes.number.isRequired,
 };
 
-export const Fav = (function ({ FavList, onSongIndexChange, onAddOneFromFav, handleDelteFromSearchList, handleAddToFavClick }) {
+export const Fav = (function ({ FavList, onSongIndexChange, onAddOneFromFav, handleDeleteFromSearchList, handleAddToFavClick }) {
     const [currentFavList, setCurrentFavList] = useState(null)
     const [rows, setRows] = useState(null)
     const [page, setPage] = useState(0);
@@ -279,7 +279,7 @@ export const Fav = (function ({ FavList, onSongIndexChange, onAddOneFromFav, han
                                                 <AddBoxOutlinedIcon sx={CRUDIcon} onClick={() => handleAddToFavClick(currentFavList.info.id, song)} />
                                             </Tooltip>
                                             <Tooltip title="删除歌曲">
-                                                <DeleteOutlineOutlinedIcon sx={CRUDIcon} onClick={() => handleDelteFromSearchList(
+                                                <DeleteOutlineOutlinedIcon sx={CRUDIcon} onClick={() => handleDeleteFromSearchList(
                                                     currentFavList.info.id, 
                                                     song.id, 
                                                     {page:page, rowsPerPage:rowsPerPage, filterString:filterString})} />

--- a/src/components/FavList.js
+++ b/src/components/FavList.js
@@ -113,7 +113,7 @@ export const FavList = memo(function ({ onSongListChange, onPlayOneFromFav, onPl
     }, [searchList, selectedList])
 
     // Delete base on ID of the song
-    const handleDelteFromSearchList = useCallback((id, songId, currentTableInfo) => {
+    const handleDeleteFromSearchList = useCallback((id, songId, currentTableInfo) => {
         let favList = id == 'FavList-Search' ? searchList : favLists.find(f => f.info.id == id)
 
         favList.songList = favList.songList.filter(s => s.id != songId)
@@ -329,7 +329,7 @@ export const FavList = memo(function ({ onSongListChange, onPlayOneFromFav, onPl
                         onSongListChange={onSongListChange}
                         onSongIndexChange={onPlayOneFromFav}
                         onAddOneFromFav={onAddOneFromFav}
-                        handleDelteFromSearchList={handleDelteFromSearchList}
+                        handleDeleteFromSearchList={handleDeleteFromSearchList}
                         handleAddToFavClick={handleAddToFavClick}
                     />}
             </Box>

--- a/src/utils/Data.js
+++ b/src/utils/Data.js
@@ -241,11 +241,9 @@ export const fetchFavList = async (mid) => {
     await Promise.all(pagesPromises)
         .then(async function (v) {
             // console.log(BVidPromises)
-            for (let index = 0; index < v.length; index++) {
-                await v[index].json().then(js =>
-                    js.data.has_more
-                    &&
-                    js.data.medias.map(m => BVidPromises.push(fetchVideoInfo(m.bvid))))
+            for (const response of v) {
+                const js = await response.json()
+                js.data.medias.forEach(m => BVidPromises.push(fetchVideoInfo(m.bvid)))
             }
 
             await Promise.all(BVidPromises).then(res => {


### PR DESCRIPTION
问题描述在 #59 

问题段落修复为
```javascript
    for (const response of v) {
        const js = await response.json()
        js.data.medias.forEach(m => BVidPromises.push(fetchVideoInfo(m.bvid)))
    }
```

修复后测试正常。`media_id=3349906669` 的收藏夹共142个视频，修复后缺失的最后2个视频正确加入列表，如图所示
![image](https://github.com/user-attachments/assets/b2381812-3ee2-4d63-916a-01e54da9aaf1)


p.s 顺手修正了以下几处'Delete'的错误拼写